### PR TITLE
Add platformio configuratoin.

### DIFF
--- a/Arduino/CCLib/Examples/CCLib_proxy/platformio.ini
+++ b/Arduino/CCLib/Examples/CCLib_proxy/platformio.ini
@@ -1,0 +1,20 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; http://docs.platformio.org/page/projectconf.html
+
+[platformio]
+src_dir = .
+
+[env:d1_mini]
+platform = espressif8266
+board = d1_mini
+framework = arduino
+monitor_speed = 9600
+upload_speed = 921600
+


### PR DESCRIPTION
This adds a platformio configuration to build the CCLib_proxy for a wemos D1 mini using platformio.

Platformio is a build system that allows building an Arduino project from the command line, without requiring the Arduino IDE. Settings like the target platform, tool chain version, libraries and their versions are specified in a text file. This allows the binary to built without human supervision (e.g. automatically on each git push).

To build, type 'pio run'. To build and upload, type 'pio run -t upload'.